### PR TITLE
BusyBox compatible stat argument

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -15,7 +15,7 @@ fi
 # Create HOME dir
 if [ -d "${UHOME}" ]
 then
-  home_owner="$(stat --format '%U' ${UHOME})"
+  home_owner="$(stat -c '%U' ${UHOME})"
   if [ $(id -u ${UNAME}) -ne $(id -u ${home_owner}) ]; then
     chown "${UID}":"${GID}" -R ${UHOME}
   fi


### PR DESCRIPTION
Make compatible with busybox stat used in [`alpine:edge`](https://github.com/JAremko/docker-x11-bridge/blob/master/Dockerfile#L1) https://busybox.net/downloads/BusyBox.html